### PR TITLE
Fix hegemony scores higher than 1

### DIFF
--- a/hege/bgpatom/bgpatom_peer.py
+++ b/hege/bgpatom/bgpatom_peer.py
@@ -63,9 +63,9 @@ class BGPAtomPeer:
             self.update_withdrawal_message(prefix)
 
     def update_announcement_message(self, prefix: str, announced_aspath: list):
-        non_prepended_aspath = utils.remove_path_prepending(announced_aspath)
-        origin_asn = non_prepended_aspath[-1]
-        atom_encoded_path = tuple(non_prepended_aspath[:-1])
+        deduplicated_aspath = utils.deduplicate_as_path(announced_aspath)
+        origin_asn = deduplicated_aspath[-1]
+        atom_encoded_path = tuple(deduplicated_aspath[:-1])
 
         path_id = self.get_path_id(atom_encoded_path)
         self.prefix_to_aspath[prefix] = path_id

--- a/hege/utils/utils.py
+++ b/hege/utils/utils.py
@@ -24,15 +24,20 @@ def str_datetime_to_timestamp(str_dt: str, fmt=DATETIME_STRING_FORMAT):
     return datetime_to_timestamp(dt)
 
 
-def remove_path_prepending(prepended_aspath: list):
-    prev = ""
-    aspath = list()
-    for asn in prepended_aspath:
-        if asn == prev:
+def deduplicate_as_path(aspath: list):
+    """Remove duplicate ASNs from the path and return the remaining path in order.
+
+    Primary purpose is to remove path prepending, but also handle cases of "invalid" AS
+    paths of the form A B A, which are rare but exist.
+    """
+    seen_asns = set()
+    dedup_aspath = list()
+    for asn in aspath:
+        if asn in seen_asns:
             continue
-        aspath.append(asn)
-        prev = asn
-    return aspath
+        dedup_aspath.append(asn)
+        seen_asns.add(asn)
+    return dedup_aspath
 
 
 def is_ip_v6(prefix: str):


### PR DESCRIPTION
There are some instances of hegemony scores higher than 1 caused by technically invalid AS paths.

A score higher than 1 can occur if an on-path AS shows up more often than the origin AS, which is used as the base for normalization. Normally this should never happen since we remove AS path prepending, but there are some non-compliant paths of the form A B A, which we did not handle before.

This PR changes the deduplication to take into account all ASes seen in the path, not just the previous one.

Fixes #4.