### PR TITLE
Fix waiting for dead collectors

### DIFF
--- a/hege/hegemony/hege_builder_helper.py
+++ b/hege/hegemony/hege_builder_helper.py
@@ -45,7 +45,7 @@ class HegeBuilderHelper:
     def read_data_for_as_hegemony(self, collector: str):
         loaded_bcscore = self.load_bcscore(collector, self.partition_id)
 
-        if loaded_bcscore is None:
+        if not loaded_bcscore:
             logging.debug(f"could not read collector {collector}'s bcscore;")
             return False, collector 
 


### PR DESCRIPTION
If there is no data available for a collecor, we want to ignore it for the rest of the analysis round.

However, `loaded_bcscore` can never be None, since it is always initialized in [`BCSSCORELoader.prepare_load_data()`](https://github.com/InternetHealthReport/as-hegemony/blob/f73ced65b5f7c24e65659c41ff6cbae5cdf8895a/hege/bcscore/bcscore_loader.py#L34) and returned by [`DataLoader.load_data()`](https://github.com/InternetHealthReport/as-hegemony/blob/f73ced65b5f7c24e65659c41ff6cbae5cdf8895a/hege/utils/data_loader.py#L24). For this to work correctly, we need to check if it is empty instead.